### PR TITLE
workflow_actions.conf

### DIFF
--- a/default/workflow_actions.conf
+++ b/default/workflow_actions.conf
@@ -1,0 +1,23 @@
+[get_parent_process_create]
+display_location = event_menu
+eventtypes = ms-sysmon-process
+fields = ParentProcessGuid, host
+label = Get parent process creation event
+search.app = search
+search.search_string = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" EventID=1 host=$host$ ProcessGuid=$ParentProcessGuid$ | table _time host Image CommandLine ParentImage ParentCommandLine User
+search.target = blank
+type = search
+search.earliest = -35d@d
+search.latest = now
+
+[get_process_create]
+display_location = event_menu
+eventtypes = ms-sysmon-process
+fields = ProcessGuid, host
+label = Get process creation event
+search.app = search
+search.search_string = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" EventID=1 host=$host$ ProcessGuid=$ProcessGuid$ | table _time host Image CommandLine ParentImage ParentCommandLine User
+search.target = blank
+type = search
+search.earliest = -35d@d
+search.latest = now


### PR DESCRIPTION
Provides workflow actions allowing for search of process creation and parent process creation events.  Searches 35 days in history by default.  35 days selected as default based on assumption that source systems reboot at least monthly to receive patches.