### PR TITLE
mask passwords example

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -63,6 +63,14 @@ Using this TA
 	Ensure that you have at least version 6.2.0 universal forwarders.
 	This is because of the Windows XML event log format.
 
+	Sysmon ProcessCreate events may pick up passwords in CommandLine
+        and ParentCommandLine fields. Depending on organizational policy you 
+	may be required to mask passwords either at search time or prior to
+	indexing. SEDCMD entries can be added to props.conf files on 
+	search heads or indexers to mask data in known positions of passwords. 
+
+        SEDCMD-pwd_rule1 = s/ -pw ([^\s\<])+/ -pw ***MASK***/g
+
 http://blogs.splunk.com/2014/11/04/splunk-6-2-feature-overview-xml-event-logs/
 
 	For additional info on Sysmon see here:

--- a/default/props.conf
+++ b/default/props.conf
@@ -1,4 +1,5 @@
 [XmlWinEventLog:Microsoft-Windows-Sysmon/Operational]
+#SEDCMD-pwd_rule1 = s/ -pw ([^\s\<])+/ -pw ***MASK***/g
 REPORT-sysmon = sysmon-eventid,sysmon-version,sysmon-level,sysmon-task,sysmon-opcode,sysmon-keywords,sysmon-created,sysmon-record,sysmon-correlation,sysmon-channel,sysmon-computer,sysmon-sid,sysmon-data
 EVAL-src_ip = SourceIp
 EVAL-src_host = SourceHostname


### PR DESCRIPTION
here's something.  

I added a commented entry to props.conf because it's important for potential users to know that SEDCMD entries should precede other field extraction types.  

Feel free to alter suggested changes.  I won't take it personally.