### PR TITLE
Fixed typo in props (:q before sourcetype)

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -1,4 +1,4 @@
-:q[XmlWinEventLog:Microsoft-Windows-Sysmon/Operational]
+[XmlWinEventLog:Microsoft-Windows-Sysmon/Operational]
 #SEDCMD-pwd_rule1 = s/ -pw ([^\s\<])+/ -pw ***MASK***/g
 REPORT-sysmon = sysmon-eventid,sysmon-version,sysmon-level,sysmon-task,sysmon-opcode,sysmon-keywords,sysmon-created,sysmon-record,sysmon-correlation,sysmon-channel,sysmon-computer,sysmon-sid,sysmon-data,sysmon-md5,sysmon-sha1,sysmon-sha256,sysmon-imphash,sysmon-hashes,sysmon-filename,sysmon-registry
 EVAL-src_ip = SourceIp


### PR DESCRIPTION
Resolves #28 extract characters at the beginning of props.conf