### PR TITLE
resolves issue #30

### DIFF
--- a/default/eventtypes.conf
+++ b/default/eventtypes.conf
@@ -5,7 +5,7 @@ search = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" EventC
 search = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" (EventCode="1" OR EventCode="5" OR EventCode="6" OR EventCode="8" OR EventCode="9" OR EventCode="10" OR EventCode="15" OR EventCode="17" OR EventCode="18")
 
 [ms-sysmon-filemod]
-search = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" EventCode="11"
+search = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" (EventCode="11" OR EventCode="2")
 
 [ms-sysmon-regmod]
 search = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" (EventCode="12" OR EventCode="13" OR EventCode="14")

--- a/default/workflow_actions.conf
+++ b/default/workflow_actions.conf
@@ -4,7 +4,7 @@ eventtypes = ms-sysmon-process
 fields = ParentProcessGuid, host
 label = Get parent process creation event
 search.app = search
-search.search_string = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" EventCode=1 host=$host$ ProcessGuid=$ParentProcessGuid$
+search.search_string = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" EventCode=1 host=$host$ ProcessGuid=$ParentProcessGuid$ $ParentProcessGuid$ | table _time host EventCode EventDescription LogonId User IntegrityLevel process ProcessId Image CommandLine CurrentDirectory Hashes ParentImage ParentCommandLine | transpose
 search.target = blank
 type = search
 search.earliest = -35d@d
@@ -12,11 +12,11 @@ search.latest = now
 
 [get_process_create]
 display_location = both
-eventtypes = ms-sysmon-process
+eventtypes = ms-sysmon-*
 fields = ProcessGuid, host
 label = Get process creation event
 search.app = search
-search.search_string = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" EventCode=1 host=$host$ ProcessGuid=$ProcessGuid$
+search.search_string = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" EventCode=1 host=$host$ ProcessGuid=$ProcessGuid$ $ProcessGuid$  | table _time host EventCode EventDescription LogonId User IntegrityLevel process ProcessId Image CommandLine CurrentDirectory Hashes ParentImage ParentCommandLine | transpose
 search.target = blank
 type = search
 search.earliest = -35d@d

--- a/default/workflow_actions.conf
+++ b/default/workflow_actions.conf
@@ -1,6 +1,6 @@
 [get_parent_process_create]
 display_location = both
-eventtypes = ms-sysmon-process
+eventtypes = ms-sysmon-*
 fields = ParentProcessGuid, host
 label = Get parent process creation event
 search.app = search


### PR DESCRIPTION
Assigned EventCode 2 (File Create Time) to ms-sysmon-filemod eventtype.

Extended "Get process creation event" workflow actions to all applicable event types, including:
- ms-sysmon-filemod
- ms-sysmon-regmod
- ms-sysmon-process
- ms-sysmon-network
- ms-sysmon-regmod
- ms-sysmon-filemod

Enhanced "Get process creation event" workflow actions to display process creation event as a transposed table instead of raw xml.

Added full text search element to "Get process creation event" workflow actions..  This improves job cost by reducing field extraction workloads.



