### PR TITLE
ms-sysmon-dns source/sourcetype change

### DIFF
--- a/default/eventtypes.conf
+++ b/default/eventtypes.conf
@@ -14,4 +14,4 @@ search = source="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" (EventCode
 search = source="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" (EventCode="19" OR EventCode="20" OR EventCode="21")
 
 [ms-sysmon-dns]
-search = sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" EventCode="22"
+search = source="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" EventCode="22"


### PR DESCRIPTION
The sourcetype is being aliased on the search head by a rename to make it xmlwineventlog, which causes this sourcetype search on ms-sysmon-dns to miss. I've updated it to be in line with the rest of the eventtypes.