### PR TITLE
Fixing broken props.conf

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -1,5 +1,5 @@
 ##Below fields extractions have been moved from [XmlWinEventLog:Microsoft-Windows-Sysmon/Operational]
-[source::XmlWinEventLog:Microsoft-Windows-Sysmon/Operational]
+[source::WinEventLog:Microsoft-Windows-Sysmon/Operational]
 #SEDCMD-pwd_rule1 = s/ -pw ([^\s\<])+/ -pw ***MASK***/g
 REPORT-sysmon = sysmon-eventid,sysmon-version,sysmon-level,sysmon-task,sysmon-opcode,sysmon-keywords,sysmon-created,sysmon-record,sysmon-correlation,sysmon-channel,sysmon-computer,sysmon-sid,sysmon-data,sysmon-md5,sysmon-sha1,sysmon-sha256,sysmon-imphash,sysmon-hashes,sysmon-filename,sysmon-registry,sysmon-dns-record-data,sysmon-dns-ip-data
 


### PR DESCRIPTION
The source stanza is incorrect. Even though renderXml=1 on inputs.conf, the 'source' is still WinEventLog:Microsoft-Windows-Sysmon/Operational