### PR TITLE
Fix to source in props.conf and addition to inputs.conf to remove Windows TA dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 # Update History
 
+## 10.5.0
+* March 3, 2020
+* https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon
+* Reverted change to source (XmlWinEventLog...), added source specification in inputs.conf to remeove dependancy on Splunk_TA_windows
+
 ## 10.4.0
 * March 2, 2020
 * Tested with Sysmon version 10

--- a/default/inputs.conf
+++ b/default/inputs.conf
@@ -1,6 +1,7 @@
 [WinEventLog://Microsoft-Windows-Sysmon/Operational]
 disabled = true
 renderXml = 1
+source = XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
 # Prevent forwarding of multiple DNSQuery logs based on complex rule groups
 # blacklist1 = EventCode="^22$" Message="(?i)QueryName:\s+(.*\.arpa\.)\s+QueryStatus:\s+(\d+)\s+QueryResults:\s+(.*)\s+Image:\s+(c:\\windows\\sysmon\.exe)$"
 # blacklist2 = EventCode="^22$" Message="(?i)QueryName:\s+(HelloWorld.local)\s+QueryStatus:\s+(\d+)\s+QueryResults:\s+(.*)\s+Image:\s+(c:\\windows\\system32\\ping\.exe)$”

--- a/default/props.conf
+++ b/default/props.conf
@@ -1,5 +1,5 @@
 ##Below fields extractions have been moved from [XmlWinEventLog:Microsoft-Windows-Sysmon/Operational]
-[source::WinEventLog:Microsoft-Windows-Sysmon/Operational]
+[source::XmlWinEventLog:Microsoft-Windows-Sysmon/Operational]
 #SEDCMD-pwd_rule1 = s/ -pw ([^\s\<])+/ -pw ***MASK***/g
 REPORT-sysmon = sysmon-eventid,sysmon-version,sysmon-level,sysmon-task,sysmon-opcode,sysmon-keywords,sysmon-created,sysmon-record,sysmon-correlation,sysmon-channel,sysmon-computer,sysmon-sid,sysmon-data,sysmon-md5,sysmon-sha1,sysmon-sha256,sysmon-imphash,sysmon-hashes,sysmon-filename,sysmon-registry,sysmon-dns-record-data,sysmon-dns-ip-data
 
@@ -26,7 +26,6 @@ EVAL-action = case(EventCode=="1","allowed",EventCode=="12" AND EventType=="Crea
 #Ports Node
 EVAL-creation_time = case(EventCode=="3",UtcTime)
 EVAL-state = case(EventCode=="3", "listening")
-
 
 #Processes Node
 EVAL-parent_process_exec = case(EventCode=="1" OR EventCode=="2" OR EventCode=="3" OR EventCode=="5" OR EventCode=="7" OR EventCode=="9" OR EventCode=="11" OR EventCode=="12" OR EventCode=="13" OR EventCode=="14" OR EventCode=="15" OR EventCode=="17" OR EventCode=="18", replace(ParentImage,"(.*\\\)(?=.*(\.\w*)$|(\w+)$)",""),1==1,"")

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -101,3 +101,8 @@ SOURCE_KEY = QueryResults
 REGEX = (?<answer>(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})+)
 REPEAT_MATCH = true
 MV_ADD = true
+
+[ta-microsoft-sysmon-fix-xml-source]
+DEST_KEY = MetaData:Source
+REGEX = <Channel>(.+?)<\/Channel>.*
+FORMAT = source::XmlWinEventLog:$1

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -101,8 +101,3 @@ SOURCE_KEY = QueryResults
 REGEX = (?<answer>(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})+)
 REPEAT_MATCH = true
 MV_ADD = true
-
-[ta-microsoft-sysmon-fix-xml-source]
-DEST_KEY = MetaData:Source
-REGEX = <Channel>(.+?)<\/Channel>.*
-FORMAT = source::XmlWinEventLog:$1


### PR DESCRIPTION
The last change of the source to WinEventLog from XmlWinEventLog breaks event-types as these were searching for the XmlWinEventLog. 

I've changed the source in props.conf back. And also forced the source to the appropriate setting in inputs.conf. 

@jwindley-splunk and I have discussed this and tested it in his environment.

This is better, as it matches the pattern used in the windows TA (i.e. XML logs have the XmlWinEventLog... source prefix), and also makes sense as this TA only supports XML event logs.

This change also removes the dependancy on the transform in the windows TA which changes XML logs source from WinEventLog... to XmlWinEventLog, making it no longer a requirement to have both installed (although the windows TA transform did not seem to be working properly anyway).