### PR TITLE
Fix process_hash mapping / Add additional process_hash mappings

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -34,7 +34,7 @@ FIELDALIAS-parent_process_guid = ParentProcessGuid AS parent_process_guid
 FIELDALIAS-parent_process_path = ParentImage AS parent_process_path
 FIELDALIAS-process_current_directory = CurrentDirectory AS process_current_directory
 EVAL-process_exec = case(EventCode=="1" OR EventCode=="2" OR EventCode=="3" OR EventCode=="5" OR EventCode=="7" OR EventCode=="9" OR EventCode=="11" OR EventCode=="12" OR EventCode=="13" OR EventCode=="14" OR EventCode=="15" OR EventCode=="17" OR EventCode=="18" OR EventCode="22", replace(Image,"(.*\\\)(?=.*(\.\w*)$|(\w+)$)",""),EventCode=="6","System",EventCode=="8" OR EventCode=="10",replace(SourceImage,"(.*\\\)(?=.*(\.\w*)$|(\w+)$)",""),1==1,"")
-FIELDALIAS-process_hash = Hashes AS process_hash
+FIELDALIAS-process_hash = hashes AS process_hash
 FIELDALIAS-process_guid = ProcessGuid AS process_guid
 FIELDALIAS-process_id = ProcessId AS process_id
 FIELDALIAS-process_integrity_level = IntegrityLevel AS process_integrity_level

--- a/default/props.conf
+++ b/default/props.conf
@@ -35,6 +35,10 @@ FIELDALIAS-parent_process_path = ParentImage AS parent_process_path
 FIELDALIAS-process_current_directory = CurrentDirectory AS process_current_directory
 EVAL-process_exec = case(EventCode=="1" OR EventCode=="2" OR EventCode=="3" OR EventCode=="5" OR EventCode=="7" OR EventCode=="9" OR EventCode=="11" OR EventCode=="12" OR EventCode=="13" OR EventCode=="14" OR EventCode=="15" OR EventCode=="17" OR EventCode=="18" OR EventCode="22", replace(Image,"(.*\\\)(?=.*(\.\w*)$|(\w+)$)",""),EventCode=="6","System",EventCode=="8" OR EventCode=="10",replace(SourceImage,"(.*\\\)(?=.*(\.\w*)$|(\w+)$)",""),1==1,"")
 FIELDALIAS-process_hash = hashes AS process_hash
+FIELDALIAS-process_hash_md5 = MD5 as process_hash_md5
+FIELDALIAS-process_hash_sha1 = SHA1 as process_hash_sha1
+FIELDALIAS-process_hash_sha256 = SHA256 as process_hash_sha256
+FIELDALIAS-process_hash_imphash = IMPHASH as process_hash_imp
 FIELDALIAS-process_guid = ProcessGuid AS process_guid
 FIELDALIAS-process_id = ProcessId AS process_id
 FIELDALIAS-process_integrity_level = IntegrityLevel AS process_integrity_level


### PR DESCRIPTION
Two commits to help resolve issues around process_hash usage. The first commit switches from a single string value (e.g. MD5=xxxxxx,SHA256=xxxxxx,IMPHASH=xxxxxx) to a multi-value with the prefixes removed (making matching against threat-intel lists work), while the second commit adds additional aliases that some orgs use to either extend the existing endpoint datamodel or to power their own.